### PR TITLE
Support Linux Mint versions 20.1, 20.2 and 20.3

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -20,7 +20,7 @@ debian_ubuntu_matrix:
     ubuntu_distribution_major_version: 20
   una: *mint-20
   uma: *mint-20
-  ulyana: *mint-20
+  ulyssa: *mint-20
   tricia:
     ubuntu_distribution_release: bionic
     ubuntu_distribution_version: 18.04

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -14,10 +14,13 @@ debian_ubuntu_matrix:
     ubuntu_distribution_release: xenial
     ubuntu_distribution_version: 16.04
     ubuntu_distribution_major_version: 16
-  ulyana:
+  ulyana: &mint-20
     ubuntu_distribution_release: focal
     ubuntu_distribution_version: 20.04
     ubuntu_distribution_major_version: 20
+  una: *mint-20
+  uma: *mint-20
+  ulyana: *mint-20
   tricia:
     ubuntu_distribution_release: bionic
     ubuntu_distribution_version: 18.04


### PR DESCRIPTION
Codenames of the mint versions can be found here: https://linuxmint.com/download_all.php